### PR TITLE
Add AKS to CI (tweak scripts)

### DIFF
--- a/Samples/AKS-scripts/run-end-to-end-perftest-example.sh
+++ b/Samples/AKS-scripts/run-end-to-end-perftest-example.sh
@@ -77,7 +77,7 @@ $KUBE get pods
 ./Deploy-AKS.sh perftestserver \
    'runAmbrosiaService.sh Server --sp '$LOCALPORT1' --rp '$LOCALPORT2' -j perftestclient -s perftestserver -n 1 -c'
 ./Deploy-AKS.sh perftestclient \
-   'runAmbrosiaService.sh Job --sp '$LOCALPORT1' --rp '$LOCALPORT2' -j perftestclient -s perftestserver --mms 65536 -n $NUM_ROUNDS -c'
+   'runAmbrosiaService.sh Job --sp '$LOCALPORT1' --rp '$LOCALPORT2' -j perftestclient -s perftestserver --mms 65536 -n '$NUM_ROUNDS' -c'
 
 set +x
 echo "-----------------------------------------------------------------------"

--- a/Samples/AKS-scripts/run-end-to-end-perftest-example.sh
+++ b/Samples/AKS-scripts/run-end-to-end-perftest-example.sh
@@ -30,12 +30,12 @@ echo "Running with these user settings:"
 echo
 
 source Defs/Common-Defs.sh # For PUBLIC_CONTAINER_NAME
-if [ ${PUBLIC_CONTAINER_NAME:+defined} ]; then
-    echo "Error: Don't set PUBLIC_CONTAINER_NAME in your AmbrosiaAKSConf.sh."
-    echo "This particular script expects to set that itself."
-    exit 1
-fi
-export PUBLIC_CONTAINER_NAME=ambrosia/ambrosia-perftest
+PUBLIC_CONTAINER_NAME=${PUBLIC_CONTAINER_NAME:-"ambrosia/ambrosia-perftest"}
+export PUBLIC_CONTAINER_NAME
+
+# Leave it running for a long time by default:
+NUM_ROUNDS=${NUM_ROUNDS:-20}
+
 
 # This should perform IDEMPOTENT OPERATIONS
 #------------------------------------------
@@ -77,7 +77,7 @@ $KUBE get pods
 ./Deploy-AKS.sh perftestserver \
    'runAmbrosiaService.sh Server --sp '$LOCALPORT1' --rp '$LOCALPORT2' -j perftestclient -s perftestserver -n 1 -c'
 ./Deploy-AKS.sh perftestclient \
-   'runAmbrosiaService.sh Job --sp '$LOCALPORT1' --rp '$LOCALPORT2' -j perftestclient -s perftestserver --mms 65536 -n 13 -c'
+   'runAmbrosiaService.sh Job --sp '$LOCALPORT1' --rp '$LOCALPORT2' -j perftestclient -s perftestserver --mms 65536 -n $NUM_ROUNDS -c'
 
 set +x
 echo "-----------------------------------------------------------------------"

--- a/Scripts/run_aks_ci.sh
+++ b/Scripts/run_aks_ci.sh
@@ -4,23 +4,39 @@ set -euo pipefail
 # This script runs an end-to-end Azure/Kubernetes test.
 
 echo "Running in directory: "`pwd`
-if [[ -d `dirname $0`/AKS-scripts ]]; then
-    cd `dirname $0`/AKS-scripts
-elif [[ -d ../AKS-scripts ]]; then
-    cd ../AKS-scripts
-else 
-    cd ./AKS-scripts
-fi
+cd ../Samples/AKS-scripts
+
 echo "Filling settings into template (Defs/AmbrosiaAKSConf.sh)..."
 cp Defs/AmbrosiaAKSConf.sh.template Defs/AmbrosiaAKSConf.sh
 sed -i 's|xyz|aksambrosiaci|'       Defs/AmbrosiaAKSConf.sh
 sed -i "s|PASTE_SUBSCRIPTION_ID_HERE|$AZURE_SUBSCRIPTION|" Defs/AmbrosiaAKSConf.sh
 
-echo "Launching end-to-end test..."
-./run-end-to-end-perftest-example.sh
+
+# TODO: Figure out how to overcome auth problems and push to private
+# Azure container registry OR authenticate and push to public
+# dockerhub.
+
+# echo
+# echo "Building Docker containers"
+# DONT_BUILD_NATIVE_IMAGE=1 DONT_BUILD_TARBALL=1 \
+#   ../../build_docker_images.sh
+# docker tag ambrosia/ambrosia-perftest ambrosia/ambrosia-ci-test
+# docker push ambrosia/ambrosia-ci-test
+# export PUBLIC_CONTAINER_NAME=ambrosia/ambrosia-ci-test
+
+# INCOMPLETE WORKAROUND:
+#
+# In the meantiime we just test the existing public images.  These
+# will periodically update (automated build), but it is not
+# *synchronized* with this CI run, so there's version skew.
+export PUBLIC_CONTAINER_NAME=ambrosia/ambrosia-perftest
+
+echo
+echo "Launching end-to-end test..." 
+NUM_ROUNDS=2 ./run-end-to-end-perftest-example.sh
 
 echo "Cleaning up..."
+# Option 1:
 # ./Clean-AKS.sh all
-
 # Leave the passive resources, but delete the active pods:
 kubectl delete pods,deployments --all

--- a/Scripts/run_aks_ci.sh
+++ b/Scripts/run_aks_ci.sh
@@ -35,8 +35,28 @@ echo
 echo "Launching end-to-end test..." 
 NUM_ROUNDS=2 ./run-end-to-end-perftest-example.sh
 
+for ((i=0; i<10; i++)); do
+    sleep 2
+    kubectl get pods
+done
+
+kubectl describe pods
+
+POD=`kubectl get pods | grep Running | grep perftestclient | head -n1 | awk '{ print $1 }'`
+
+if [ "$POD" == ""]; then
+    echo "ERROR: could not find running client pod."
+    exit 1
+fi
+
+kubectl logs -f "$POD" \
+  || echo "Ok if this exits with error for now."
+
 echo "Cleaning up..."
 # Option 1:
 # ./Clean-AKS.sh all
+
 # Leave the passive resources, but delete the active pods:
 kubectl delete pods,deployments --all
+
+


### PR DESCRIPTION
This enables continuous integration -- running PerformanceTestInterruptable in Kubernetes in Azure.

It should help ensure that these scripts keep working, because they are published as a "Sample" for users.