### PR TITLE
Change UWPExample client apps to not call ImpulseHandlers until after recovery

### DIFF
--- a/InternalImmortals/UWPExample/GraphicalApp/Form1.cs
+++ b/InternalImmortals/UWPExample/GraphicalApp/Form1.cs
@@ -87,7 +87,7 @@ namespace GraphicalApp
 
         private void Timer_Tick(object sender, EventArgs e)
         {
-            if (immortal != null)
+            if (immortal != null && immortal.DoneRecovering())
             {
                 immortal.HandleUserInputExternal(_mousePosInternal.X, _mousePosInternal.Y, _mouseDownInternal);
             }

--- a/InternalImmortals/UWPExample/GraphicalAppUWP/MainPage.xaml.cs
+++ b/InternalImmortals/UWPExample/GraphicalAppUWP/MainPage.xaml.cs
@@ -108,7 +108,10 @@ namespace GraphicalAppUWP
                 return;
             }
 
-            immortal.HandleUserInputExternal((int)pointerPosInternal.X, (int)pointerPosInternal.Y, pointerDownInternal);
+            if (immortal.DoneRecovering())
+            {
+                immortal.HandleUserInputExternal((int)pointerPosInternal.X, (int)pointerPosInternal.Y, pointerDownInternal);
+            }
 
             canvas.Children.Clear();
 

--- a/InternalImmortals/UWPExample/GraphicalImmortal/GraphicalImmortal.cs
+++ b/InternalImmortals/UWPExample/GraphicalImmortal/GraphicalImmortal.cs
@@ -24,6 +24,8 @@ namespace GraphicalImmortalImpl
         [DataMember]
         private bool _prevOtherMouseDown = false;
 
+        private bool _doneRecovering = false;
+
         public GraphicalImmortal(string remoteName)
         {
             _remoteName = remoteName;
@@ -93,6 +95,16 @@ namespace GraphicalImmortalImpl
         {
             _remoteProxy = GetProxy<IGraphicalImmortalProxy>(_remoteName);
             return true;
+        }
+
+        protected override void BecomingPrimary()
+        {
+            _doneRecovering = true;
+        }
+
+        public bool DoneRecovering()
+        {
+            return _doneRecovering;
         }
     }
 }


### PR DESCRIPTION
Previously, the UWPExample client apps started calling ImpulseHandlers immediately after creating their Immortals. This behavior had the potential to cause bugs in scenarios with recovery, since the ImpulseHandlers were getting called during recovery. This pull request fixes the UWPExample client apps to wait until after recovery is finished before calling ImpulseHandlers.

This PR only touches UWPExample files and shouldn't have any impact on the core Ambrosia code.