### PR TITLE
make the console color setting exception safe

### DIFF
--- a/Samples/HelloWorld/Client1/Program.cs
+++ b/Samples/HelloWorld/Client1/Program.cs
@@ -8,6 +8,20 @@ using System.Threading.Tasks;
 
 namespace Client1
 {
+    class ConsoleColorScope : IDisposable
+    {
+        public static ConsoleColorScope SetForeground(ConsoleColor color)
+        {
+            Console.ForegroundColor = color;
+            return new ConsoleColorScope();
+        }
+
+        public void Dispose()
+        {
+            Console.ResetColor();
+        }
+    }
+
     [DataContract]
     class Client1 : Immortal<IClient1Proxy>, IClient1
     {
@@ -29,17 +43,20 @@ namespace Client1
 
             _server.ReceiveMessageFork("\n!! Client: Hello World 1!");
 
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("\n!! Client: Sent message 1.");
-            Console.WriteLine("\n!! Client: Press enter to continue (will send 2&3)");
-            Console.ResetColor();
+            using (ConsoleColorScope.SetForeground(ConsoleColor.Yellow))
+            {
+                Console.WriteLine("\n!! Client: Sent message 1.");
+                Console.WriteLine("\n!! Client: Press enter to continue (will send 2&3)");
+            }
 
             Console.ReadLine();
             _server.ReceiveMessageFork("\n!! Client: Hello World 2!");
             _server.ReceiveMessageFork("\n!! Client: Hello World 3!");
 
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("\n!! Client: Press enter to shutdown.");
+            using (ConsoleColorScope.SetForeground(ConsoleColor.Yellow))
+            {
+                Console.WriteLine("\n!! Client: Press enter to shutdown.");
+            }
 
             Console.ReadLine();
             Program.finishedTokenQ.Enqueue(0);

--- a/Samples/HelloWorld/Client3/Program.cs
+++ b/Samples/HelloWorld/Client3/Program.cs
@@ -7,6 +7,20 @@ using System.Threading.Tasks;
 
 namespace Client3
 {
+    class ConsoleColorScope : IDisposable
+    {
+        public static ConsoleColorScope SetForeground(ConsoleColor color)
+        {
+            Console.ForegroundColor = color;
+            return new ConsoleColorScope();
+        }
+
+        public void Dispose()
+        {
+            Console.ResetColor();
+        }
+    }
+
     // Because this Immortal makes async instance calls, it, and the associated generated proxies and base classes, must be
     // compiled DEBUG. For an explanation, see HelloWorldExplained.
     [DataContract]
@@ -26,22 +40,24 @@ namespace Client3
         protected override async Task<bool> OnFirstStart()
         {
             _server = GetProxy<IServerProxy>(_serverName);
-            Console.ForegroundColor = ConsoleColor.Yellow;
 
-            var t1 = _server.ReceiveMessageAsync("\n!! Client: Hello World 3 Message #1!");
-            Console.WriteLine("\n!! Client: Sent message #1.");
+            using (ConsoleColorScope.SetForeground(ConsoleColor.Yellow))
+            {
+                var t1 = _server.ReceiveMessageAsync("\n!! Client: Hello World 3 Message #1!");
+                Console.WriteLine("\n!! Client: Sent message #1.");
 
-            var res1 = await t1;
-            Console.WriteLine($"\n!! Client: Message #1 completed. Server acknowledges processing {res1} messages.");
+                var res1 = await t1;
+                Console.WriteLine($"\n!! Client: Message #1 completed. Server acknowledges processing {res1} messages.");
 
-            var t2 = _server.ReceiveMessageAsync("\n!! Client: Hello World 3 Message #2!");
-            Console.WriteLine("\n!! Client: Sent message #2.");
+                var t2 = _server.ReceiveMessageAsync("\n!! Client: Hello World 3 Message #2!");
+                Console.WriteLine("\n!! Client: Sent message #2.");
 
-            var res2 = await t2;
-            Console.WriteLine($"\n!! Client: Message #2 completed. Server acknowledges processing {res2} messages.");
+                var res2 = await t2;
+                Console.WriteLine($"\n!! Client: Message #2 completed. Server acknowledges processing {res2} messages.");
 
-            Console.WriteLine("\n!! Client: Shutting down");
-            Program.finishedTokenQ.Enqueue(0);
+                Console.WriteLine("\n!! Client: Shutting down");
+                Program.finishedTokenQ.Enqueue(0);
+            }
             return true;
         }
     }

--- a/Samples/HelloWorld/Server/Program.cs
+++ b/Samples/HelloWorld/Server/Program.cs
@@ -7,6 +7,20 @@ using System.Threading.Tasks;
 
 namespace Server
 {
+    class ConsoleColorScope : IDisposable
+    {
+        public static ConsoleColorScope SetForeground(ConsoleColor color)
+        {
+            Console.ForegroundColor = color;
+            return new ConsoleColorScope();
+        }
+
+        public void Dispose()
+        {
+            Console.ResetColor();
+        }
+    }
+
     class Program
     {
         [DataContract]
@@ -21,9 +35,10 @@ namespace Server
 
             public async Task<int> ReceiveMessageAsync(string message)
             {
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine("\n!! SERVER Received message from a client: " + message);
-                Console.ResetColor();
+                using (ConsoleColorScope.SetForeground(ConsoleColor.Green))
+                {
+                    Console.WriteLine("\n!! SERVER Received message from a client: " + message);
+                }
 
                 _messagesReceived++;
                 return _messagesReceived;


### PR DESCRIPTION
Bug in Client1 sample left the console yellow, and ctrl+c in the samples would do the same.  This fixes that.