### PR TITLE
Refactor so shard / non-shard cases can use the same code

### DIFF
--- a/Ambrosia/Ambrosia/Initialize.cs
+++ b/Ambrosia/Ambrosia/Initialize.cs
@@ -1,0 +1,71 @@
+﻿using CRA.ClientLibrary;
+using System.IO;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Ambrosia
+{
+    public class AmbrosiaRuntimeParams
+    {
+        public int serviceReceiveFromPort;
+        public int serviceSendToPort;
+        public string serviceName;
+        public string AmbrosiaBinariesLocation;
+        public string serviceLogPath;
+        public bool? createService;
+        public bool pauseAtStart;
+        public bool persistLogs;
+        public bool activeActive;
+        public long logTriggerSizeMB;
+        public string storageConnectionString;
+        public long currentVersion;
+        public long upgradeToVersion;
+    }
+
+    public static class AmbrosiaRuntimeParms
+    {
+        public static bool _looseAttach = false;
+    }
+
+    public class AmbrosiaNonShardedRuntime : VertexBase
+    {
+        private AmbrosiaRuntime Runtime { get; set; }
+        public AmbrosiaNonShardedRuntime()
+        {
+            Runtime = new AmbrosiaRuntime();
+        }
+
+        public override async Task InitializeAsync(object param)
+        {
+            // Workaround because of parameter type limitation in CRA
+            AmbrosiaRuntimeParams p = new AmbrosiaRuntimeParams();
+            XmlSerializer xmlSerializer = new XmlSerializer(p.GetType());
+            using (StringReader textReader = new StringReader((string)param))
+            {
+                p = (AmbrosiaRuntimeParams)xmlSerializer.Deserialize(textReader);
+            }
+
+            bool sharded = false;
+
+            Runtime.Initialize(
+                p.serviceReceiveFromPort,
+                p.serviceSendToPort,
+                p.serviceName,
+                p.serviceLogPath,
+                p.createService,
+                p.pauseAtStart,
+                p.persistLogs,
+                p.activeActive,
+                p.logTriggerSizeMB,
+                p.storageConnectionString,
+                p.currentVersion,
+                p.upgradeToVersion,
+                ClientLibrary,
+                AddAsyncInputEndpoint,
+                AddAsyncOutputEndpoint
+            );
+
+            return;
+        }
+    }
+}

--- a/ImmortalCoordinator/Program.cs
+++ b/ImmortalCoordinator/Program.cs
@@ -96,7 +96,7 @@ namespace CRA.Worker
                 dataProvider, descriptor, connectionsPoolPerWorker);
 
             worker.DisableDynamicLoading();
-            worker.SideloadVertex(new AmbrosiaRuntime(), "ambrosia");
+            worker.SideloadVertex(new AmbrosiaNonShardedRuntime(), "ambrosia");
 
             worker.Start();
         }


### PR DESCRIPTION
The shard / non-shard cases in CRA use different API. Ideally,
we would have a base class for the common API and have the
shard case inherit from the base class + either VertexBase or
ShardedVertexBase. However, C# does not support multiple
inheritence.

To get around this, we move the initialized methods into an
non-shard case that calls the original Ambrosia initialize
function. This way we can easily add the sharded case.

To make this cleaner and potentially easier to test, we move this
logic into a different file.