### PR TITLE
Improve the documentation in HelloWorld samples

### DIFF
--- a/Samples/HelloWorld/ActiveActive-Windows.md
+++ b/Samples/HelloWorld/ActiveActive-Windows.md
@@ -31,13 +31,6 @@ To run all these, instead of 2 process pairs, we now need 4 (8 processes and con
  dotnet ImmortalCoordinator.dll -instanceName=server -port=2500
 ```
 
-To run the client ImmortalCoordinator:
-
-```bat
-cd %AMBROSIATOOLS%\x64\Release\netcoreapp3.1
-dotnet ImmortalCoordinator.dll -instanceName=client -port=1500
-```
-
 To run the Immortal Coordinator for the first server replica
 
  ```bat
@@ -76,7 +69,7 @@ dotnet Server.dll server TWOPROC 4001 4000
 To run the HelloWorld client:
 
 ```bat
-cd Client1\bin\x64\Debug\netcoreapp2.2
+cd Client1\bin\x64\Debug\netcoreapp3.1
 dotnet Client1.dll
 ```
 Like the AddReplica gesture, the server ImmortalCoordinator calls may use a -aa flag, although it's not necessary since this was already established when registering the server instance and its replicas.

--- a/Samples/HelloWorld/HOWTO-WINDOWS-OneProc.md
+++ b/Samples/HelloWorld/HOWTO-WINDOWS-OneProc.md
@@ -30,7 +30,7 @@ For the purpose of this tutorial, we'll assume the following parameters:
 
 ### Storage Connection String
 
-Ambrosia uses an Azure table to maintain and discover information about your application's immortals and their status. To access this information, all Ambrosia tools and libraries need a connection string to an Azure storage account stored in the environment variable `%AZURE_STORAGE_CONN_STRING%`. To run this sample, you must therefore create an Azure Storage account if you don't already have one, and set the environment variable to contain its connection string.
+Ambrosia uses an Azure table to maintain and discover information about your application's immortals and their status. To access this information, all Ambrosia tools and libraries need a connection string to an Azure storage account stored in the environment variable `%AZURE_STORAGE_CONN_STRING%`. To run this sample, you must therefore create an Azure Storage account if you don't already have one, and set the environment variable to contain its connection string (Please refer to following [link](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string) for more details).
 
 ### Registering the Immortal instances
 

--- a/Samples/HelloWorld/HOWTO-WINDOWS-TwoProc.md
+++ b/Samples/HelloWorld/HOWTO-WINDOWS-TwoProc.md
@@ -32,7 +32,7 @@ For the purpose of this tutorial, we'll assume the following parameters:
 
 ### Storage Connection String
 
-Ambrosia uses an Azure table to maintain and discover information about your application's immortals and their status. To access this information, all Ambrosia tools and libraries need a connection string to an Azure storage account stored in the environment variable `%AZURE_STORAGE_CONN_STRING%`. To run this sample, you must therefore create an Azure Storage account if you don't already have one, and set the environment variable to contain its connection string.
+Ambrosia uses an Azure table to maintain and discover information about your application's immortals and their status. To access this information, all Ambrosia tools and libraries need a connection string to an Azure storage account stored in the environment variable `%AZURE_STORAGE_CONN_STRING%`. To run this sample, you must therefore create an Azure Storage account if you don't already have one, and set the environment variable to contain its connection string (Please refer to following [link](https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string) for more details).
 
 ### Registering the Immortal instances
 


### PR DESCRIPTION
Pull request that improves the documentation in HelloWorld samples.

1. Add a link that has more detailed explanations to configure a connection string for an Azure storage account.
2. Remove the instruction to run a separate ImmortalCoordinator for the client from [ActiveActive-Windows.md](https://github.com/microsoft/AMBROSIA/blob/master/Samples/HelloWorld/ActiveActive-Windows.md) due to the absence of implementations in clients supporting "TWOPROC".